### PR TITLE
Update settings.js

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -8,9 +8,9 @@ export default {
   AppId: existingSettings.AppId || 1,
   AppName: existingSettings.AppName || 'BK Sample App',
   AppUrl: existingSettings.AppUrl || 'http://localhost:1234/',
-  ApiBase: 'http://bkp1api.azurewebsites.net/',
-  SocketUrl: 'http://bkp1api.azurewebsites.net/signalr',
-  BetKingUrlBase: 'http://bkp1.azurewebsites.net/',
+  ApiBase: 'https://bkp1api.azurewebsites.net/',
+  SocketUrl: 'https://bkp1api.azurewebsites.net/signalr',
+  BetKingUrlBase: 'https://bkp1.azurewebsites.net/',
   RegisterUrl: 'account/register',
   LoginUrl: 'account/login',
   AccountManageUrl: 'manage/index'


### PR DESCRIPTION
Use https because accessing withdraw/deposit window on 'http' will result to permission error. https://i.gyazo.com/61742404efa87937be86587861123508.png